### PR TITLE
Changed Room model id to UUIDField instead of shortuuid, bugfixes 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ recursive-include django_chatter/static *
 recursive-include django_chatter/templates *
 recursive-exclude chatter *
 recursive-exclude docs/build *
+recursive-exclude tests/ *

--- a/clear-database.sh
+++ b/clear-database.sh
@@ -1,2 +1,2 @@
 rm db.sqlite3
-rm -rf chat/__pycache__/ chat/migrations/ chatter/__pycache__/
+rm -rf django_chatter/__pycache__/ django_chatter/migrations/ chatter/__pycache__/

--- a/clear-postgres.sh
+++ b/clear-postgres.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Clear migrations
+rm -rf django_chatter/migrations
+rm -rf django_chatter/__pycache__/
+rm -rf chatter/migrations
+rm -rf chatter/__pycache__/
+
+# Clear postgres chatter db and recreate
+psql -U postgres -c 'drop database if exists chatter;'
+psql -U postgres -c 'create database chatter;'
+psql -U postgres -c "grant all privileges on database chatter to chatteradmin;"
+psql -U postgres -c "alter role chatteradmin createdb;"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 django==2.0.9
 channels==2.1.7
-shortuuid==0.5.0
 bleach==3.1.0
 channels-redis==2.3.3
 psycopg2==2.7.7

--- a/django_chatter/consumers.py
+++ b/django_chatter/consumers.py
@@ -4,6 +4,7 @@ from .models import *
 from django.contrib.auth import get_user_model
 from channels.db import database_sync_to_async
 import bleach
+from uuid import UUID
 
 #Time libraries used to record the time when the user disconnects.
 #New messages will be derived from this time in the view.
@@ -92,9 +93,11 @@ class ChatConsumer(AsyncWebsocketConsumer):
         self.schema_name = self.scope.get('schema_name', None)
         self.multitenant = self.scope.get('multitenant', False)
         for param in self.scope['path'].split('/'):
-            if len(param) == 22: # ShortUUID length
-                room_id = param
+            try:
+                room_id = UUID(param, version=4)
                 break
+            except ValueError:
+                pass
         try:
             self.room = await get_room(room_id, self.multitenant, self.schema_name)
             if self.multitenant:

--- a/django_chatter/models.py
+++ b/django_chatter/models.py
@@ -1,4 +1,4 @@
-import shortuuid
+import uuid
 
 from django.conf import settings
 from django.db import models
@@ -18,10 +18,9 @@ class DateTimeModel(models.Model):
         abstract = True
 
 class Room(DateTimeModel):
-    id = models.URLField(primary_key=True,
-            default=shortuuid.ShortUUID().random,
-            editable=False
-        )
+    id = models.UUIDField(primary_key=True,
+            default=uuid.uuid4,
+            editable=False)
     members = models.ManyToManyField(settings.AUTH_USER_MODEL)
 
     def __str__(self):

--- a/django_chatter/static/js/chat-window.js
+++ b/django_chatter/static/js/chat-window.js
@@ -51,7 +51,7 @@ function startWebSocket(websocket_url) {
 		var sender = data['sender'];
 		var received_room_id = data['room_id'];
 		if (username === sender) {
-			$('#'+received_room_id).css('font-weight', 'bold');
+			// $('#'+received_room_id).css('font-weight', 'bold');
 			$('#'+received_room_id).parent().parent().prepend($('#'+received_room_id).parent());
 			$('#chat-dialog').append(
 			'<div class="message-container">'
@@ -63,6 +63,11 @@ function startWebSocket(websocket_url) {
 				+ '<div class = "message message-received">' + warning + '</div>'
 				+ '</div>');
 			}
+
+			$('#send-message').val('');
+			document.getElementById('chat-dialog').scrollTop
+			= document.getElementById('chat-dialog').scrollHeight;
+
 		} else {
 			if (received_room_id === room_id) {
 				$('#'+received_room_id).css('font-weight', 'bold');
@@ -84,10 +89,6 @@ function startWebSocket(websocket_url) {
 				$('#'+received_room_id).parent().parent().prepend($('#'+received_room_id).parent());
 			}
 		}
-
-		$('#send-message').val('');
-		document.getElementById('chat-dialog').scrollTop
-		= document.getElementById('chat-dialog').scrollHeight;
 	}
 
 	//Notify when the websocket closes abruptly.

--- a/django_chatter/static/js/chat-window.js
+++ b/django_chatter/static/js/chat-window.js
@@ -133,6 +133,7 @@ $(function() {
 	$("div[id*=" + room_id + "]").css("background", "#87ddc2");
 });
 
+// Animation to slide up chat window and slide down user list in mobile devices
 $('.fa-arrow-left').click(function() {
 	$(this).hide();
 	$('.chat-container').slideUp();

--- a/django_chatter/static/js/fetch-messages.js
+++ b/django_chatter/static/js/fetch-messages.js
@@ -1,0 +1,18 @@
+// This module fetches past messages once the user scrolls
+// to top.
+
+
+var didScroll = false;
+
+$('#chat-dialog').scroll(function() {
+    didScroll = true;
+});
+
+setInterval(function() {
+    if ( didScroll ) {
+        didScroll = false;
+        // console.log("scrolled"); // This works.
+        // Check your page position and then
+        // Load in more results
+    }
+}, 250);

--- a/django_chatter/templates/django_chatter/chat-window.html
+++ b/django_chatter/templates/django_chatter/chat-window.html
@@ -67,4 +67,5 @@
 	var username = '{{user.username}}';
 </script>
 <script src = "{% static 'js/chat-window.js' %}"></script>
+<script src = "{% static 'js/fetch-messages.js' %}"></script>
 {% endblock content %}

--- a/django_chatter/templates/django_chatter/chat-window.html
+++ b/django_chatter/templates/django_chatter/chat-window.html
@@ -42,9 +42,6 @@
 				</div>
 			{% else %}
 				<div class="message-container">
-					<div class="message message-receiver">
-						{{message.sender.username}}:
-					</div>
 					<div class="message message-received">
 						{{message.text}}
 					</div>

--- a/django_chatter/templates/django_chatter/chatroom-list.html
+++ b/django_chatter/templates/django_chatter/chatroom-list.html
@@ -47,4 +47,3 @@
 	var get_chat_url = '{% url "django_chatter:get_chat_url" %}';
 	var chatter_index = '{% url "django_chatter:index" %}';
 </script>
-<script src = "{% static 'js/searchuser.js' %}"></script>

--- a/django_chatter/templates/django_chatter/chatroom-list.html
+++ b/django_chatter/templates/django_chatter/chatroom-list.html
@@ -47,3 +47,4 @@
 	var get_chat_url = '{% url "django_chatter:get_chat_url" %}';
 	var chatter_index = '{% url "django_chatter:index" %}';
 </script>
+<script src = "{% static 'js/searchuser.js' %}"></script>

--- a/django_chatter/templates/django_chatter/index.html
+++ b/django_chatter/templates/django_chatter/index.html
@@ -30,6 +30,5 @@
 	<!--AI==========================================================
 		JS that generates list of users for the user to search.
 	===========================================================AI-->
-	<script src = "{% static 'js/searchuser.js' %}"></script>
 	<script src = "{% static 'js/index.js' %}"></script>
 {% endblock content %}


### PR DESCRIPTION
- Due to unforeseen migration issues when using `shortuuid`'s random UUID generator, I've changed the id field on room to UUID entirely. 
- The way the scripts were being loaded, the chatroom had two scripts executing the same commands, so whenever a user searched and created a room with another user, the scripts ended up creating two room altogether; sort-of race condition
- `views.py` is much shorter now to the use of the `get_room` utility. 
- Fixed a bug where if a user received a message, whatever they were writing would get reset to the empty string. 